### PR TITLE
Support TransformStamped messages

### DIFF
--- a/oomact_ros/include/aslam/calibration/ros/InputFeederI.h
+++ b/oomact_ros/include/aslam/calibration/ros/InputFeederI.h
@@ -28,11 +28,14 @@ class InputFeederImpl : public InputFeederI {
   virtual ~InputFeederImpl() = default;
 
   virtual void feed(const ::rosbag::MessageInstance & m, ObservationManagerI & obsManager) const override {
-    const Timestamp t = static_cast<const Derived*>(this)->feed(*m.instantiate<Msg>(), receiver_, obsManager);
-    if(t != InvalidTimestamp()){
-      const Sensor & sensor = getSensorFromReceiver(receiver_);
-      VLOG(3) << "Feeding measurement to " << getNameFromSensor(sensor) << " at t=" << obsManager.secsSinceStart(t) << " secs.";
-      obsManager.addMeasurementTimestamp(t, sensor);
+    auto mInst = m.instantiate<Msg>();
+    if(mInst){ //TODO O : gain efficiency by check out the type of a topic in a bag first and then don't even instantiate the other feeders
+      const Timestamp t = static_cast<const Derived*>(this)->feed(*mInst, receiver_, obsManager);
+      if(t != InvalidTimestamp()){
+        const Sensor & sensor = getSensorFromReceiver(receiver_);
+        VLOG(3) << "Feeding measurement to " << getNameFromSensor(sensor) << " at t=" << obsManager.secsSinceStart(t) << " secs.";
+        obsManager.addMeasurementTimestamp(t, sensor);
+      }
     }
   }
  private:

--- a/oomact_ros/src/feeder/PoseSensorInputFeeder.cpp
+++ b/oomact_ros/src/feeder/PoseSensorInputFeeder.cpp
@@ -5,6 +5,7 @@
 #include <rosbag/bag.h>
 #include <rosbag/view.h>
 #include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/TransformStamped.h>
 
 #include "aslam/calibration/ros/InputFeederFactoryRegistry.h"
 #include "aslam/calibration/ros/InputFeederFactoryI.h"
@@ -15,6 +16,12 @@ namespace aslam {
 namespace calibration {
 namespace ros {
 
+bool msg2Measurement(const geometry_msgs::TransformStamped &msg, PoseMeasurement & m){
+  m.t = rosVector3dToEigenVector3(msg.transform.translation);
+  m.q = rosQuaternionToVector4dXYZW(msg.transform.rotation);
+  return true;
+}
+
 bool msg2Measurement(const geometry_msgs::PoseStamped &msg, PoseMeasurement & m){
   m.t = rosVector3dToEigenVector3(msg.pose.position);
   m.q = rosQuaternionToVector4dXYZW(msg.pose.orientation);
@@ -24,6 +31,7 @@ bool msg2Measurement(const geometry_msgs::PoseStamped &msg, PoseMeasurement & m)
 namespace {
 InputFeederFactoryRegistry::RegistryEntry regEntries[] = {
     new InputFeederFactoryForMessageWithHeader<geometry_msgs::PoseStamped, PoseMeasurement>,
+    new InputFeederFactoryForMessageWithHeader<geometry_msgs::TransformStamped, PoseMeasurement>,
 };
 }
 


### PR DESCRIPTION
@ZacharyTaylor , I've also realized that and did this. Sorry for the duplication. The changes in `InputFeederI` were necessary to support feeders that wait for different kinds of messages.

So you mostly got it right. Missing piece was to register it with https://github.com/ethz-asl/oomact/compare/feature/supportTransformStamped?expand=1#diff-3eaf2554915e213a7666166759738dfdR34. This allows the RosInputProvider to find the feeder factory.